### PR TITLE
Add a note about dictionaries in Python 3.6 onwards being ordered

### DIFF
--- a/basics.ipynb
+++ b/basics.ipynb
@@ -2135,7 +2135,7 @@
    "metadata": {},
    "source": [
     "#### Dictionaries\n",
-    "A *dictionary* is a dynamic, unordered container. Instead of using integers to access the elements of the container, the dictionary uses *keys* to access the stored *values*. The dictionary can be created by listing the comma separated key-value pairs in braces. Keys and values are separated by a colon. A tuple (key,value) is called an *item* of the dictionary.\n",
+    "A *dictionary* is a dynamic, unordered container (from Python 3.6+ dictionaries are ordered). Instead of using integers to access the elements of the container, the dictionary uses *keys* to access the stored *values*. The dictionary can be created by listing the comma separated key-value pairs in braces. Keys and values are separated by a colon. A tuple (key,value) is called an *item* of the dictionary.\n",
     "\n",
     "Let's demonstrate the dictionary creation and usage:"
    ]


### PR DESCRIPTION
What do you think about adding some clarification about this 🙂 ?

Some background info: https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6